### PR TITLE
Potential fix for code scanning alert no. 9: Wrong type of arguments to formatting function

### DIFF
--- a/source/client/cl_parse.c
+++ b/source/client/cl_parse.c
@@ -974,7 +974,7 @@ void CL_ParseServerMessage( msg_t *msg )
 
 	if( cl_shownet->integer == 1 )
 	{
-		Com_Printf( "%i ", msg->cursize );
+		Com_Printf( "%lu ", msg->cursize );
 	}
 	else if( cl_shownet->integer >= 2 )
 	{


### PR DESCRIPTION
Potential fix for [https://github.com/inter0hm/war0hm-qfusion/security/code-scanning/9](https://github.com/inter0hm/war0hm-qfusion/security/code-scanning/9)

To fix the problem, we need to ensure that the format specifier in the `printf` function matches the type of the argument being passed. In this case, we should use the `%lu` format specifier for an `unsigned long` type.

- Change the format specifier from `%i` to `%lu` in the `Com_Printf` function call on line 977.
- This change should be made in the file `source/client/cl_parse.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
