### PR TITLE
Potential fix for code scanning alert no. 24: Wrong type of arguments to formatting function

### DIFF
--- a/source/qcommon/mem.c
+++ b/source/qcommon/mem.c
@@ -969,7 +969,7 @@ void Mem_ValidationAllAllocations() {
 		}
 	}
 	if(memTrackCount != stats.memTrackCount) 
-		Com_Printf("[!] number of tracked units is mismatched table is corrupted (found: %d expected: %d)", memTrackCount, stats.memTrackCount);
+		Com_Printf("[!] number of tracked units is mismatched table is corrupted (found: %u expected: %d)", memTrackCount, stats.memTrackCount);
 
 	assert(memTrackCount == stats.memTrackCount);
 	if (numberErrors > 0)


### PR DESCRIPTION
Potential fix for [https://github.com/inter0hm/war0hm-qfusion/security/code-scanning/24](https://github.com/inter0hm/war0hm-qfusion/security/code-scanning/24)

To fix the problem, we need to ensure that the format specifier in the `Com_Printf` function call matches the type of the `memTrackCount` variable. Since `memTrackCount` is of type `uint_fast32_t`, we should use the `%u` format specifier, which is intended for unsigned integers.

- Change the format specifier from `%d` to `%u` in the `Com_Printf` function call on line 972.
- Ensure that the change is applied only to the relevant part of the code without altering any other functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
